### PR TITLE
Launch GitUp via the command line tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gitup",
     "displayName": "GitUp",
     "description": "Open project in GitUp",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "Braver",
     "repository": {
         "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,10 +5,10 @@ import child_process = require("child_process");
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(vscode.commands.registerCommand("extension.opengitup", () => {
-    var app = "/Applications/GitUp.app";
+    var commandLineTool = "/Applications/GitUp.app/Contents/SharedSupport/gitup";
     var project = vscode.workspace.rootPath;
     if (project) {
-      child_process.execFile("open", ["-a", app, project]);
+      child_process.exec(commandLineTool);
     }
   }));
 }


### PR DESCRIPTION
This patch allows "Open in GitUp" to handle more complex repository/workspace arrangements gracefully.

## The Problem
Opening GitUp with the `open` command works well for projects where the repository root and the VSCode workspace root path are the same. It doesn’t work for projects where the workspace root is a child of the repository root.

On my current project, I have a repository, `MyApp`, that contains two directories `mobile-app/`, and `cloud-backend/`. Each directory is its own VSCode workspace. When I’m working in either workspace, running “Open in GitUp" fails with an error: "could not find repository from `/path/to/workspace`.”

You can see the problem directly in [this test repo](https://github.com/joechrysler/gitup-test-repository).

## The Solution

GitUp’s command line tool handles this sort of situation nicely. It uses [a function from libgit2](https://github.com/libgit2/libgit2/blob/a8f19f819ea5b9a949b439702893f87c2c655141/src/repository.c#L428) to find the repository root when called from anywhere within the repo.

This patch modifies the extension to launch GitUp via the command line tool.

## To Try it Out

From any workspace that is itself a git repo or is contained within a git repo, run "Open in GitUp". It should work. 🙂 